### PR TITLE
blog: Fix typos ("Journey to libbpf 1.0" post)

### DIFF
--- a/content/posts/libbpf-v1.md
+++ b/content/posts/libbpf-v1.md
@@ -104,7 +104,7 @@ includes also:
   - [libbpf-sys](https://github.com/libbpf/libbpf-sys) Rust low-level bindings.
 
 **Thanks a lot for your continuing help and contributions, without which
-libbpf wouldn't be were it is today!**
+libbpf wouldn't be where it is today!**
 
 To make this not just a celebratory post, in the rest of it I'll try to
 describe major breaking changes users should be aware of and summarize
@@ -407,7 +407,7 @@ To improve debuggability, we've also added ability to flexibly capture BPF
 verifier log into user-provided log buffers the help of `kernel_log_buf`,
 `kernel_log_size`, and `kernel_log_level` open options, passed into
 `bpf_object__open_file()` and `bpf_object__open_mem()`. To get even more
-control, each BPF program's logi buffer can be set and retrieved with
+control, each BPF program's log buffer can be set and retrieved with
 `bpf_program__[set_]log_buf()` and `bpf_program__[set_]log_level()` APIs.
 This control of BPF verifier log output comes very handy during active
 development and troubleshooting.


### PR DESCRIPTION
Fix minor typos spotted while reading the post.